### PR TITLE
Add workflow to create CalVer release on PR merge

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -1,0 +1,105 @@
+name: Create CalVer Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches:
+      - main
+
+jobs:
+  create-release:
+    # Only run if the PR was actually merged (not just closed)
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Calculate CalVer version
+        id: calver
+        run: |
+          # Get current date components
+          YEAR=$(date +%y)
+          MONTH=$(date +%-m)
+          DAY=$(date +%-d)
+          
+          # Base version without micro
+          BASE_VERSION="${YEAR}.${MONTH}.${DAY}"
+          
+          # Fetch all tags
+          git fetch --tags
+          
+          # Find all tags matching today's date pattern
+          TODAY_TAGS=$(git tag -l "${BASE_VERSION}_*" | sort -V)
+          
+          # Calculate micro version
+          if [ -z "$TODAY_TAGS" ]; then
+            MICRO=0
+          else
+            # Get the last tag for today and extract the micro version
+            LAST_TAG=$(echo "$TODAY_TAGS" | tail -n 1)
+            LAST_MICRO=$(echo "$LAST_TAG" | cut -d'_' -f2)
+            MICRO=$((LAST_MICRO + 1))
+          fi
+          
+          # Create full version
+          VERSION="${BASE_VERSION}_${MICRO}"
+          
+          echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Generated version: ${VERSION}"
+
+      - name: Update package.json
+        run: |
+          VERSION="${{ steps.calver.outputs.version }}"
+          
+          # Check if package.json exists
+          if [ -f "package.json" ]; then
+            # Update version in package.json using jq
+            sudo apt-get update && sudo apt-get install -y jq
+            jq --arg version "$VERSION" '.version = $version' package.json > package.json.tmp
+            mv package.json.tmp package.json
+            
+            echo "Updated package.json to version ${VERSION}"
+          else
+            echo "No package.json found, skipping update"
+          fi
+
+      - name: Commit package.json changes
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+          
+          if [ -f "package.json" ]; then
+            git add package.json
+            
+            # Only commit if there are changes
+            if ! git diff --staged --quiet; then
+              git commit -m "chore: bump version to ${{ steps.calver.outputs.version }}"
+              git push
+            else
+              echo "No changes to package.json"
+            fi
+          fi
+
+      - name: Create Release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ steps.calver.outputs.version }}
+          release_name: ${{ steps.calver.outputs.version }}
+          body: |
+            ## Release ${{ steps.calver.outputs.version }}
+            
+            **Changes:**
+            Merged PR #${{ github.event.pull_request.number }}: ${{ github.event.pull_request.title }}
+            
+            **Full Changelog:** ${{ github.event.pull_request.html_url }}
+          draft: false
+          prerelease: false


### PR DESCRIPTION
This workflow creates a CalVer release upon merging a pull request. It updates the version in package.json and creates a GitHub release with the new version.