### PR TITLE
Programmatically added labels to the username and password input boxes

### DIFF
--- a/src/routes/auth/signin/+page.svelte
+++ b/src/routes/auth/signin/+page.svelte
@@ -52,7 +52,9 @@
     
     <h1 class="text-2xl font-medium mb-4">Sign In</h1>
 
+    <label class="sr-only" for="email">Username</label>
     <input class="py-2.5 sm:py-3 px-4 block w-full border border-outline rounded sm:text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none" id="email" type="text" placeholder="Username" bind:value={username} required autocomplete="username" />
+    <label class="sr-only" for="password">Password</label>
     <input class="py-2.5 sm:py-3 px-4 block w-full border border-outline rounded sm:text-sm focus:border-blue-500 focus:ring-blue-500 disabled:opacity-50 disabled:pointer-events-none" id="password" type="password" placeholder="Password" bind:value={password} required autocomplete="current-password" />
     
     <div class="flex">


### PR DESCRIPTION
The username and password input boxes did not have labels attached to them. While placeholders can work in some assistive technologies or instances, as soon as you give focus to the input box, the placeholder goes away.

Having labels programmatically added will make sure that everyone will be able to access the accessible name for the form fields. I made them screenreader-only so that they don't appear on the front-end and keep the UI the same.