### PR TITLE
68 logout button

### DIFF
--- a/src/routes/system/+layout.svelte
+++ b/src/routes/system/+layout.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import type { ApplicationConfig } from "../../config";
-
+    import { authClient } from "$lib/client";
+    import Button from "$components/actions/button/Button.svelte";
 
     const { children, title, data } = $props<{ 
         children: () => any, 
@@ -12,7 +13,7 @@
 
     async function logout() {
         await authClient.signOut();
-        location.href = "/login";
+        location.href = "/auth/signin/";
     }
 </script>
 
@@ -68,8 +69,7 @@
                 </ul>
             </li>
             <li>
-                <button onClick={logout}>Sign Out
-                </button>
+                <Button onclick={logout}>Sign Out</Button>
             </li>
         </ul>
     </aside>


### PR DESCRIPTION
I managed to implement the logout functionality on the /system page.

I would recommend that the logout function be put someplace where it can be called from any file. I tried a few different places like hooks.server.ts and layout.server.ts, but apparently you can only put certain functions in those files.

Also, the Svelte example in the better-auth docs used the deprecated "on:click", my VS Code autocorrected to "onClick", and the method to use is actually "onclick." Once I got the "all lowercase" memo, the function easily worked as expected, but that nit was annoying!